### PR TITLE
seqdata: fix undo when making a change without leaving the bottom area

### DIFF
--- a/src/seqdata.cpp
+++ b/src/seqdata.cpp
@@ -427,6 +427,12 @@ seqdata::on_button_release_event(GdkEventButton* a_p0)
         m_seq->unselect();
         m_seq->set_dirty();
     }
+    
+    if(m_seq->get_hold_undo())
+    {
+        m_seq->push_undo(true);
+        m_seq->set_hold_undo(false);
+    }
 
     update_pixmap();
     queue_draw();
@@ -536,12 +542,6 @@ seqdata::on_motion_notify_event(GdkEventMotion* a_p0)
 bool
 seqdata::on_leave_notify_event(GdkEventCrossing* p0)
 {
-    if(m_seq->get_hold_undo())
-    {
-        m_seq->push_undo(true);
-        m_seq->set_hold_undo(false);
-    }
-
     update_pixmap();
     queue_draw();
     return true;


### PR DESCRIPTION
Hi, I'm working on yet another fork of seq24 (heavy focused on the live part) and your additions to this software are helping a lot, thank you ! Here is a little patch that does what the title says :)  